### PR TITLE
Removed unused code

### DIFF
--- a/lib/citeprocmodule.js
+++ b/lib/citeprocmodule.js
@@ -8347,8 +8347,8 @@ CSL.Attributes["@variable"] = function (state, arg) {
                     }
                     break;
                 } else if ("object" === typeof Item[variable]) {
-                    if (Item[variable].length) {
-                    }
+                    //if (Item[variable].length) {
+                    //}
                     break;
                 } else if ("string" === typeof Item[variable] && Item[variable]) {
                     output = true;


### PR DESCRIPTION
Removed unused code that is causing a HTTP 500 response when
an attribute within the request is null. The code that has been
removed looks to be uncomplete and it also exists within CiteProcs
master.
